### PR TITLE
Fix code scanning alert no. 116: Information exposure through an exception

### DIFF
--- a/events/views.py
+++ b/events/views.py
@@ -536,8 +536,7 @@ def cancel_registration(request, event_id):
         return JsonResponse({
             'success': False,
             'error': 'An unexpected system error occurred',
-            'status_code': 'SYSTEM_ERROR',
-            'details': str(unexpected_error)
+            'status_code': 'SYSTEM_ERROR'
         }, status=500)
 
 def send_cancellation_confirmation_email(user, event):


### PR DESCRIPTION
Fixes [https://github.com/KenyanAudo03/Campus_Interaction/security/code-scanning/116](https://github.com/KenyanAudo03/Campus_Interaction/security/code-scanning/116)

To fix the problem, we need to ensure that the detailed error message and stack trace are not exposed to the end user. Instead, we should return a generic error message while logging the detailed error on the server. This can be achieved by removing the `details` field from the JSON response and ensuring that only a generic error message is returned.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
