### PR TITLE
Fix code scanning alert no. 110: Information exposure through an exception

### DIFF
--- a/events/api_views.py
+++ b/events/api_views.py
@@ -13,6 +13,7 @@ from .serializers import (
 )
 from .filters import EventFilter
 # events/api_views.py
+import logging
 from rest_framework import viewsets, status
 from rest_framework.response import Response
 from .models import Event
@@ -145,8 +146,9 @@ class EventViewSet(viewsets.ModelViewSet):
             }, status=status.HTTP_200_OK)
         
         except Exception as e:
+            logging.error("An error occurred during partial update: %s", str(e))
             return Response({
-                'error': str(e)
+                'error': 'An internal error has occurred. Please try again later.'
             }, status=status.HTTP_400_BAD_REQUEST)
 
     @action(detail=True, methods=['post'], permission_classes=[IsAuthenticated, EventUpdatePermission])


### PR DESCRIPTION
Fixes [https://github.com/KenyanAudo03/Campus_Interaction/security/code-scanning/110](https://github.com/KenyanAudo03/Campus_Interaction/security/code-scanning/110)

To fix the problem, we need to ensure that detailed error messages and stack traces are not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to log the exception and return a generic error message.

1. Import the `logging` module to enable logging of exceptions.
2. Replace the current exception handling block to log the exception and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
