### PR TITLE
Fix code scanning alert no. 117: Information exposure through an exception

### DIFF
--- a/events/views.py
+++ b/events/views.py
@@ -728,9 +728,10 @@ def register_event(request, event_id):
                     return JsonResponse(response_data)
                 
                 except ValidationError as ve:
+                    logger.error(f"Validation error: {ve}", exc_info=True)
                     return JsonResponse({
                         'success': False,
-                        'error': str(ve),
+                        'error': 'Validation error occurred',
                         'status_code': 'VALIDATION_ERROR'
                     }, status=400)
                 


### PR DESCRIPTION
Fixes [https://github.com/KenyanAudo03/Campus_Interaction/security/code-scanning/117](https://github.com/KenyanAudo03/Campus_Interaction/security/code-scanning/117)

To fix the problem, we need to ensure that detailed exception information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the code to log the `ValidationError` and return a generic error message in the JSON response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
